### PR TITLE
Release 1.0.2

### DIFF
--- a/wal_steam.py
+++ b/wal_steam.py
@@ -206,7 +206,7 @@ def firstRun():
 
 def checkMetroWal():
     # check if wal_steam has been run before
-    if os.path.isdir(metroInstall):
+    if os.path.isdir(metroResource): # TEMP FIX FOR AUR RELEASE (install will be overhauled in 1.1.0)
         return True
     else:
         return False
@@ -232,5 +232,5 @@ def main(arguments):
             makeStyle(colors)
 
 if __name__ == '__main__':
-    arguments = docopt(__doc__, version='Wal Steam 1.0.0') # create the flags from the comment
+    arguments = docopt(__doc__, version='Wal Steam 1.0.2') # create the flags from the comment
     main(arguments)


### PR DESCRIPTION
This fixes issue #27 which is causing the aur package to re-download metro. A cleaner fix of not using the resources folder at all and switching to ~/.cache will come in 1.1.0 (very soon)