### PR TITLE
git: Expand gitignore to ignore pyc files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 # Ignore vim swap files
 *.swp
 
+# Ignore Python pyc files
+*.pyc
+


### PR DESCRIPTION
When running `wal_steam` Python creates compiled bytecode versions of the `py` files. This change adds them to the `.gitignore` file so they aren't accidentally added to the repo.