### PR TITLE
Update to Metro 4.3.1 with matching patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ A little program that themes the colors for Metro for steam from `wal`or `wpg`. 
 
 `wal_steam` is a tiny program that is meant to work with either `wal` or `wpgtk`, by reading the colors they generate and making a color theme for a slightly tweaked version of Metro for Steam.
 
-[Wal](https://github.com/dylanaraps/pywal) is a little program for linux that creates a terminal color scheme based on your wallpaper (in addition to being able to set the wallpaper and a few other 
+[Wal](https://github.com/dylanaraps/pywal) is a little program for linux that creates a terminal color scheme based on your wallpaper (in addition to being able to set the wallpaper and a few other
 interesting features).
 
 [Wpgtk](https://github.com/deviantfero/wpgtk) is based on wal, but with the added feature of being able to generate gtk themes with the colors and bring a nice simple ui to wal.
 
-[Metro for steam](http://metroforsteam.com/) is a very nice looking skin for steam. We also add the [community patch](https://steamcommunity.com/groups/metroforsteam/discussions/0/527273789693410879/) which makes the skin render well on linux.
+[Metro for steam](http://metroforsteam.com/) is a very nice looking skin for steam. We also add the [community patch](https://steamcommunity.com/groups/metroskin/discussions/0/141136086931804907) which makes the skin render well on linux.
 
 ## Install
 

--- a/wal_steam.py
+++ b/wal_steam.py
@@ -41,7 +41,6 @@ WPG_COLORS        = os.path.join(HOME_DIR, ".config", "wpg", "current.css")
 METRO_URL        = "http://metroforsteam.com/downloads/4.3.1.zip"
 METRO_ZIP        = os.path.join(CACHE_DIR, "metroZip.zip")
 METRO_DIR        = os.path.join(CACHE_DIR, "metroZip")
-METRO_COPY       = os.path.join(METRO_DIR, "Metro 4.3.1")
 
 METRO_PATCH_URL  = "https://github.com/redsigma/UPMetroSkin/archive/e43f55b43f8ae565e162da664887051a1c76c5b4.zip" # A link to the version we've tested rather than the latest, just in case they break things upstream.
 METRO_PATCH_ZIP  = os.path.join(CACHE_DIR, "metroPatchZip.zip")
@@ -227,20 +226,20 @@ def getColors(mode):
 
 def checkSkin(steam_dir, dpi):
     # check for skin and patch in cache
-    if not (os.path.isdir(METRO_COPY) and os.path.isdir(METRO_PATCH_COPY)):
+    if not (os.path.isdir(METRO_DIR) and os.path.isdir(METRO_PATCH_COPY)):
         # metro skin and patch not found in cache, download and make
         makeSkin()
     # check for patched skin in steam skin directory
     if not os.path.isdir(os.path.join(steam_dir, SKIN_NAME)):
         # patched skin not found in steam, copy it over
         print("Installing skin")
-        copy_tree(METRO_COPY, os.path.join(steam_dir, SKIN_NAME))
+        copy_tree(METRO_DIR, os.path.join(steam_dir, SKIN_NAME))
     else:
         print("Wal Steam skin found")
         if (dpi==1):
             # skin was not found, copy it over
             print("Forcing skin install for High DPI patches")
-            copy_tree(METRO_COPY, os.path.join(steam_dir, SKIN_NAME))
+            copy_tree(METRO_DIR, os.path.join(steam_dir, SKIN_NAME))
 
 def makeSkin():
     # download metro for steam and extract
@@ -274,7 +273,7 @@ def makeSkin():
     z.close()
 
     # finally apply the patch
-    copy_tree(METRO_PATCH_COPY, METRO_COPY) # use copy_tree not copytree, shutil copytree is broken
+    copy_tree(METRO_PATCH_COPY, METRO_DIR) # use copy_tree not copytree, shutil copytree is broken
 
 def makeConfig():
     # download the config for wal_steam
@@ -290,7 +289,7 @@ def makeConfig():
 def makeDpi():
     # apply the high dpi
     print ("Applying the high dpi patches")
-    copy_tree(METRO_PATCH_HDPI, METRO_COPY)
+    copy_tree(METRO_PATCH_HDPI, METRO_DIR)
 
 def delConfig():
     # delete the config

--- a/wal_steam.py
+++ b/wal_steam.py
@@ -74,7 +74,7 @@ def setColors(colors, variables, walColors, alpha, steam_dir):
 
     wal_styles = "\n".join(patches)
     custom_styles = custom_styles.replace(
-        "light=\"Helvetica Neue Thin\" [$OSX]\n}", "light=\"Helvetica Neue Thin\" [$OSX]\n" + wal_styles + "}")
+        "}\n\nstyles{", wal_styles + "}\n\nstyles{")
 
     f = open(COLORS_FILE, "w")
     f.write(custom_styles)

--- a/wal_steam.py
+++ b/wal_steam.py
@@ -25,8 +25,8 @@ from distutils.dir_util import copy_tree  # copytree from shutil is broken so us
 HOME_DIR          = os.getenv("HOME", os.getenv("USERPROFILE")) # should be crossplatform
 CACHE_DIR         = os.path.join(HOME_DIR, ".cache", "wal_steam")
 CONFIG_DIR        = os.path.join(HOME_DIR, ".config", "wal_steam")
-SKIN_NAME         = "Metro 4.2.4 Wal_Mod"
-VERSION           = "1.2.5"
+SKIN_NAME         = "Metro 4.3.1 Wal_Mod"
+VERSION           = "1.3.0"
 CONFIG_FILE       = "wal_steam.conf"
 COLORS_FILE       = os.path.join(CACHE_DIR, "colors.styles")
 CONFIG_URL        = "https://raw.githubusercontent.com/kotajacob/wal_steam_config/master/wal_steam.conf"
@@ -38,16 +38,16 @@ STEAM_DIR_WINDOWS = "C:\Program Files (x86)\Steam\skins"
 WAL_COLORS        = os.path.join(HOME_DIR, ".cache", "wal", "colors.css")
 WPG_COLORS        = os.path.join(HOME_DIR, ".config", "wpg", "current.css")
 
-METRO_URL        = "http://metroforsteam.com/downloads/4.2.4.zip"
+METRO_URL        = "http://metroforsteam.com/downloads/4.3.1.zip"
 METRO_ZIP        = os.path.join(CACHE_DIR, "metroZip.zip")
 METRO_DIR        = os.path.join(CACHE_DIR, "metroZip")
-METRO_COPY       = os.path.join(METRO_DIR, "Metro 4.2.4")
+METRO_COPY       = os.path.join(METRO_DIR, "Metro 4.3.1")
 
-METRO_PATCH_URL  = "https://codeload.github.com/redsigma/UPMetroSkin/zip/196feafc14deae103355b4fee1ecc4cda9288c7f" # A link to the version we've tested rather than the latest, just in case they break things upstream.
+METRO_PATCH_URL  = "https://github.com/redsigma/UPMetroSkin/archive/e43f55b43f8ae565e162da664887051a1c76c5b4.zip" # A link to the version we've tested rather than the latest, just in case they break things upstream.
 METRO_PATCH_ZIP  = os.path.join(CACHE_DIR, "metroPatchZip.zip")
 METRO_PATCH_DIR  = os.path.join(CACHE_DIR, "metroPatchZip")
-METRO_PATCH_COPY = os.path.join(METRO_PATCH_DIR, "UPMetroSkin-196feafc14deae103355b4fee1ecc4cda9288c7f", "Unofficial 4.2.4 Patch", "Main Files [Install First]")
-METRO_PATCH_HDPI = os.path.join(METRO_PATCH_DIR, "UPMetroSkin-196feafc14deae103355b4fee1ecc4cda9288c7f", "Unofficial 4.2.4 Patch", "Extras", "High DPI", "Increased fonts", "Install")
+METRO_PATCH_COPY = os.path.join(METRO_PATCH_DIR, "UPMetroSkin-e43f55b43f8ae565e162da664887051a1c76c5b4", "Unofficial 4.3.1 Patch", "Main Files [Install First]")
+METRO_PATCH_HDPI = os.path.join(METRO_PATCH_DIR, "UPMetroSkin-e43f55b43f8ae565e162da664887051a1c76c5b4", "Unofficial 4.3.1 Patch", "Extras", "High DPI", "Increased fonts", "Install")
 
 def tupToPrint(tup):
     tmp = ' '.join(map(str, tup)) # convert the tupple (rgb color) to a string ready to print

--- a/wal_steam.py
+++ b/wal_steam.py
@@ -28,7 +28,7 @@ CONFIG_DIR        = os.path.join(HOME_DIR, ".config", "wal_steam")
 SKIN_NAME         = "Metro 4.3.1 Wal_Mod"
 VERSION           = "1.3.0"
 CONFIG_FILE       = "wal_steam.conf"
-COLORS_FILE       = os.path.join(CACHE_DIR, "colors.styles")
+COLORS_FILE       = os.path.join(CACHE_DIR, "custom.styles")
 CONFIG_URL        = "https://raw.githubusercontent.com/kotajacob/wal_steam_config/master/wal_steam.conf"
 
 STEAM_DIR_OTHER   = os.path.expanduser("~/.steam/steam/skins")
@@ -38,9 +38,10 @@ STEAM_DIR_WINDOWS = "C:\Program Files (x86)\Steam\skins"
 WAL_COLORS        = os.path.join(HOME_DIR, ".cache", "wal", "colors.css")
 WPG_COLORS        = os.path.join(HOME_DIR, ".config", "wpg", "current.css")
 
-METRO_URL        = "http://metroforsteam.com/downloads/4.3.1.zip"
-METRO_ZIP        = os.path.join(CACHE_DIR, "metroZip.zip")
-METRO_DIR        = os.path.join(CACHE_DIR, "metroZip")
+METRO_URL                 = "http://metroforsteam.com/downloads/4.3.1.zip"
+METRO_ZIP                 = os.path.join(CACHE_DIR, "metroZip.zip")
+METRO_DIR                 = os.path.join(CACHE_DIR, "metroZip")
+METRO_COLORS_FILE         = os.path.join(METRO_DIR, "custom.styles")
 
 METRO_PATCH_URL  = "https://github.com/redsigma/UPMetroSkin/archive/e43f55b43f8ae565e162da664887051a1c76c5b4.zip" # A link to the version we've tested rather than the latest, just in case they break things upstream.
 METRO_PATCH_ZIP  = os.path.join(CACHE_DIR, "metroPatchZip.zip")
@@ -61,74 +62,28 @@ def setColors(colors, variables, walColors, alpha, steam_dir):
     except FileNotFoundError:
         print("No file to remove")
 
-    f = open(COLORS_FILE, 'w')
+    f = open(METRO_COLORS_FILE, 'r')
+    custom_styles = f.read()
+    f.close()
 
-    # First write the variables we aren't changing
-    f.write('\"settings.styles\"\n')
-    f.write('{\n')
-    f.write('\tcolors\n')
-    f.write('\t{\n')
-    f.write('\t\tnone=\"0 0 0 0\"\n')
-    f.write('\t\tFocus_T=\"0 114 198 30.6\"\n')
-    f.write('\t\twhite03=\"255 255 255 7.65\"\n')
-    f.write('\t\twhite08=\"255 255 255 20.4\"\n')
-    f.write('\t\twhite05=\"255 255 255 12.75\"\n')
-    f.write('\t\twhite10=\"255 255 255 25.5\"\n')
-    f.write('\t\twhite12=\"255 255 255 30.6\"\n')
-    # f.write('\t\twhite15=\"255 255 255 \"\n') this was commented in the file...
-    f.write('\t\twhite20=\"255 255 255 51\"\n')
-    f.write('\t\twhite24=\"255 255 255 61.2\"\n')
-    f.write('\t\twhite25=\"255 255 255 63.75\"\n')
-    f.write('\t\twhite35=\"255 255 255 89.25\"\n')
-    f.write('\t\twhite45=\"255 255 255 114.75\"\n')
-    f.write('\t\twhite50=\"255 255 255 127.5\"\n')
-    f.write('\t\twhite75=\"255 255 255 191.25\"\n')
-    f.write('\t\twhite=\"255 255 255 255\"\n')
-    f.write('\t\tblack03=\"0 0 0 7.65\"\n')
-    f.write('\t\tblack08=\"0 0 0 20.4\"\n')
-    f.write('\t\tblack05=\"0 0 0 12.75\"\n')
-    f.write('\t\tblack10=\"0 0 0 25.5\"\n')
-    f.write('\t\tblack12=\"0 0 0 30.6\"\n')
-    # f.write('\t\tblack15=\"0 0 0 38.25\"\n') this was commented in the file too...
-    f.write('\t\tblack20=\"0 0 0 51\"\n')
-    f.write('\t\tblack24=\"0 0 0 61.2\"\n')
-    f.write('\t\tblack35=\"0 0 0 106\"\n')
-    f.write('\t\tblack25=\"0 0 0 63.75\"\n')
-    f.write('\t\tblack75=\"0 0 0 191.25\"\n')
-    f.write('\t\tBlack=\"0 0 0 255\"\n')
-    f.write('\t\tScroll_blu=\"88 168 242 165\"\n')
-    f.write('\t\tScroll_blu_s=\"103 193 245 175\"\n')
-    f.write('\t\tDetailsBackground=\"Black45\"\n')
-    f.write('\t\tDetailPanels=\"black45\"\n')
-    f.write('\t\tOverlaySidePanels=\"255 255 255 144.75\"\n')
-    f.write('\t\tOverlayHover05=\"255 255 255 12.75\"\n')
-    f.write('\t\ttransparent_notification=\"5 5 5 229.5\"\n')
-    f.write('\t\tchatframe=\"White50\"\n')
-    f.write('\t\tScrollBar=\"86 86 86 255\"\n')
-    f.write('\t\tScrollBarH=\"110 110 110 255\"\n')
-    f.write('\t\tGrey1=\"40 40 40 255\"\n')
-    f.write('\t\tGrey2=\"48 48 48 255\"\n')
-    f.write('\t\tGrey3=\"75 75 75 255\"\n')
-    f.write('\t\tClientBGTransparent=\"43 43 43 191.25\"\n')
-    f.write('\t\tRed=\"255 0 0 255\"\n')
-    f.write('\t\tW10close_Red_h=\"232 18 35 255\"\n')
-    f.write('\t\tW10close_Red_p=\"241 112 121 255\"\n')
-
-    # Now write the variables we will be changing
+    patches = []
     ii = 0
     for i in variables:
-        f.write('\t\t' + i + '=\"' + tupToPrint(colors[int(walColors[ii])]) + ' ' + str(alpha[ii])  +  '\"\n')
+        patches.append(i + '="' + tupToPrint(colors[int(walColors[ii])]) + ' ' + str(alpha[ii]) + '"')
         ii = ii + 1
 
-    # Final formatting stuff
-    f.write('\t}\n')
-    f.write('}\n')
+    wal_styles = "\n".join(patches)
+    custom_styles = custom_styles.replace(
+        "light=\"Helvetica Neue Thin\" [$OSX]\n}", "light=\"Helvetica Neue Thin\" [$OSX]\n" + wal_styles + "}")
+
+    f = open(COLORS_FILE, "w")
+    f.write(custom_styles)
     f.close()
 
     # now copy it to the proper place based on the os
     shutil.copy(COLORS_FILE, os.path.join(steam_dir, SKIN_NAME))
 
-    # cleanup by removing generated color file
+    # cleanup by removing generated color files
     os.remove(COLORS_FILE)
     print("Wal colors are now patched and ready to go")
     print("If this is your first run you may have to ")


### PR DESCRIPTION
This PR fixes #67 and #65.

Since 4.3.0 introduced broad changes to .styles structure in the Metro skin package, the patching mechanism is broken with newer Metro versions. I modified the setColors method to patch custom.styles instead of colors.styles, in order to keep the changes introduced by wal_steam within a smaller scope and make patching more robust against future changes to upstream.