### PR TITLE
Add option to change the default font

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Usage:
   wal_steam.py ( -s ) ["/home/kota/bin/custom_steam_install/skins/"]
   wal_steam.py (-h | --help)
   wal_steam.py (-v | --version)
+  wal_steam.py (-f | --fonts) ["Ubuntu, Ubuntu Bold, Ubuntu Medium, Ubuntu Light"]
 
 Options:
   -h --help            show this help message and exit
@@ -60,6 +61,7 @@ Options:
   -u                   force update cache and config file
   -d                   apply HiDPI community patch
   -s "/steam/skins"    specify a custom steam skins folder to use
+  -f --fonts           specify custom fonts
 ```
 
 ## Screenshots

--- a/wal_steam.py
+++ b/wal_steam.py
@@ -49,11 +49,15 @@ METRO_PATCH_DIR  = os.path.join(CACHE_DIR, "metroPatchZip")
 METRO_PATCH_COPY = os.path.join(METRO_PATCH_DIR, "UPMetroSkin-e43f55b43f8ae565e162da664887051a1c76c5b4", "Unofficial 4.3.1 Patch", "Main Files [Install First]")
 METRO_PATCH_HDPI = os.path.join(METRO_PATCH_DIR, "UPMetroSkin-e43f55b43f8ae565e162da664887051a1c76c5b4", "Unofficial 4.3.1 Patch", "Extras", "High DPI", "Increased fonts", "Install")
 
+# default Metro fonts
+LINUX_FONT = "Segoe UI"
+OSX_FONT = "Helvetica Neue"
+
 def tupToPrint(tup):
     tmp = ' '.join(map(str, tup)) # convert the tupple (rgb color) to a string ready to print
     return tmp
 
-def setColors(colors, variables, walColors, alpha, steam_dir):
+def setCustomStyles(colors, variables, walColors, alpha, steam_dir, custom_font = ""):
     print ("Patching new colors")
 
     # delete the old colors file if present in cache
@@ -76,6 +80,9 @@ def setColors(colors, variables, walColors, alpha, steam_dir):
     custom_styles = custom_styles.replace(
         "}\n\nstyles{", wal_styles + "}\n\nstyles{")
 
+    if custom_font:
+        custom_styles = replaceFonts(custom_styles, custom_font)
+
     f = open(COLORS_FILE, "w")
     f.write(custom_styles)
     f.close()
@@ -89,6 +96,17 @@ def setColors(colors, variables, walColors, alpha, steam_dir):
     print("If this is your first run you may have to ")
     print("enable Metro Wal Mod skin in steam then ")
     print("simply restart steam!")
+
+
+def replaceFonts(styles, font):
+    print("Patching custom font")
+
+    replacements = {LINUX_FONT: font, OSX_FONT: font}
+
+    for old, new in replacements.items():
+        styles = styles.replace(old, new)
+
+    return styles
 
 ###################
 # color functions #
@@ -354,6 +372,9 @@ def getArgs():
     arg.add_argument("-s",
             help="Enter a custom steam skin directory.")
 
+    arg.add_argument("-f", "--font",
+            help="Enter a custom font. WARNING: Make sure the font is installed on your system.")
+
     arg.add_argument("-d", action="store_true",
             help="Apply high dpi patches.")
 
@@ -402,6 +423,13 @@ def main():
         # C:\Program Files (x86)\Steam\skins - used on windows
         oSys = getOs()
 
+    # allow the user to enter a custom font
+    if arguments.font:
+        font = arguments.font
+        print("Using custom font: " + arguments.font)
+    else:
+        font = ""
+
     # update the cache and config then exit
     if arguments.u:
         print("Force updating cache and config")
@@ -426,7 +454,7 @@ def main():
     alpha = getConfigAlpha()
 
     # finally create a temp colors.styles and copy it in updating the skin
-    setColors(colors, variables, walColors, alpha, oSys)
+    setCustomStyles(colors, variables, walColors, alpha, oSys, font)
 
 if __name__ == '__main__':
     main()

--- a/wal_steam.py
+++ b/wal_steam.py
@@ -369,7 +369,7 @@ def getOs():
 def parseFontArgs(rawArgs):
     splitArgs = [arg.strip() for arg in rawArgs.split(",")]
 
-    if len(splitArgs) < 4:
+    if len(splitArgs) != 4:
         print("Error: You must specify all four custom font styles.")
         sys.exit(1)
 


### PR DESCRIPTION
This implements the enhancement proposed in #57 by providing an additional CLI option for specifying a custom font.

Since there are four different font styles to be taken into consideration (base, semibold, semilight, and light), the option takes a comma-separated list of fonts, one for each style. There are no separate options for OSX fonts; the script simply replaces all default font definitions with the specified custom fonts.

For example, if you want to apply colours from wal and replace the default font with Ubuntu, run the script like this:

`wal_steam.py -w --fonts 'Ubuntu, Ubuntu Bold, Ubuntu Medium, Ubuntu Light'`

Screenshot with Ubuntu font applied:
![metro-ubuntu-font](https://user-images.githubusercontent.com/22562624/46416913-13cacb00-c718-11e8-88aa-4c1838cbc83f.png)

