### PR TITLE
Fixed patch download errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Options:
   -d                   apply HiDPI community patch
   -s "/steam/skins"    specify a custom steam skins folder to use
   -f --fonts           specify custom fonts
+  -a --attempts        specify the max number of patch download attempts (DEFAULT=5)
 ```
 
 ## Screenshots

--- a/wal_steam.py
+++ b/wal_steam.py
@@ -414,8 +414,7 @@ def getArgs():
             {CLI_YELLOW}Example:{CLI_END} 'Open Sans, Open Sans Semibold, Open Sans Semilight, Open Sans Light'
             {CLI_RED}WARNING:{CLI_END} Fonts must already be installed on your system.'''))
     
-    arg.add_argument("-a", "--attempts",
-            help="Set the number of patch download attempts (DEFAULT=5)")
+    arg.add_argument("-a", "--attempts", help="Set the number of patch download attempts (DEFAULT=5)")
 
     return arg.parse_args()
 
@@ -475,9 +474,9 @@ def main():
         print("Run with -w or -g to apply and re-enable wal_steam")
         sys.exit()
 
-    if arguments.a:
+    if arguments.attempts:
         try:
-            attempts_bound = int(arguments.a)
+            attempts_bound = int(arguments.attempts)
             MAX_PATCH_DL_ATTEMPTS = attempts_bound
         except:
             print("Error setting maximum patch download attempts, using default (5).")

--- a/wal_steam.py
+++ b/wal_steam.py
@@ -51,6 +51,7 @@ METRO_PATCH_ZIP  = os.path.join(CACHE_DIR, "metroPatchZip.zip")
 METRO_PATCH_DIR  = os.path.join(CACHE_DIR, "metroPatchZip")
 METRO_PATCH_COPY = os.path.join(METRO_PATCH_DIR, "UPMetroSkin-e43f55b43f8ae565e162da664887051a1c76c5b4", "Unofficial 4.3.1 Patch", "Main Files [Install First]")
 METRO_PATCH_HDPI = os.path.join(METRO_PATCH_DIR, "UPMetroSkin-e43f55b43f8ae565e162da664887051a1c76c5b4", "Unofficial 4.3.1 Patch", "Extras", "High DPI", "Increased fonts", "Install")
+MAX_PATCH_DL_ATTEMPTS = 5
 
 # CLI colour and style sequences
 CLI_RED    = "\033[91m"
@@ -242,14 +243,22 @@ def makeSkin():
     z.close()
 
     # download metro for steam patch and extract
-    print("Downloading Metro patch")
-    try:
-        opener = urllib.request.build_opener()
-        opener.addheaders = [{'User-Agent', 'Mozilla/5.0'}]
-        urllib.request.install_opener(opener)
-        urllib.request.urlretrieve(METRO_PATCH_URL, METRO_PATCH_ZIP)
-    except:
-        print("Error: downloading needed patch file. Check your connection and try again.")
+    print("Attempting to download Metro patch")
+    patch_dl_attempts = 0
+    patch_dld = False
+    while (patch_dl_attempts <= MAX_PATCH_DL_ATTEMPTS) and not patch_dld:
+        try:
+            opener = urllib.request.build_opener()
+            opener.addheaders = [{'User-Agent', 'Mozilla/5.0'}]
+            urllib.request.install_opener(opener)
+            urllib.request.urlretrieve(METRO_PATCH_URL, METRO_PATCH_ZIP)
+            patch_dld = True
+        except:
+            patch_dl_attempts += 1
+            print("Error: download attempt" + str(patch_dl_attempts) + " failed.")
+
+    if not patch_dld:
+        print("Error: patch download attempts failed, exiting...")
         sys.exit(1)
 
     z = zipfile.ZipFile(METRO_PATCH_ZIP, 'r')

--- a/wal_steam.py
+++ b/wal_steam.py
@@ -413,6 +413,9 @@ def getArgs():
             {CLI_BOLD}Available styles:{CLI_END} basefont, semibold, semilight, light.
             {CLI_YELLOW}Example:{CLI_END} 'Open Sans, Open Sans Semibold, Open Sans Semilight, Open Sans Light'
             {CLI_RED}WARNING:{CLI_END} Fonts must already be installed on your system.'''))
+    
+    arg.add_argument("-a", "--attempts",
+            help="Set the number of patch download attempts (DEFAULT=5)")
 
     return arg.parse_args()
 
@@ -471,6 +474,13 @@ def main():
         print("Cache and config updated")
         print("Run with -w or -g to apply and re-enable wal_steam")
         sys.exit()
+
+    if arguments.a:
+        try:
+            attempts_bound = int(arguments.a)
+            MAX_PATCH_DL_ATTEMPTS = attempts_bound
+        except:
+            print("Error setting maximum patch download attempts, using default (5).")
 
     # check for the cache, the skin, and get them if needed
     checkInstall(oSys, dpi)

--- a/wal_steam.py
+++ b/wal_steam.py
@@ -20,6 +20,7 @@ import zipfile                            # extracting the zip files
 import sys
 import argparse                           # argument parsing
 import textwrap
+import time
 import re
 from distutils.dir_util import copy_tree  # copytree from shutil is broken so use copy_tree
 from argparse import RawTextHelpFormatter
@@ -246,7 +247,7 @@ def makeSkin():
     print("Attempting to download Metro patch")
     patch_dl_attempts = 0
     patch_dld = False
-    while (patch_dl_attempts <= MAX_PATCH_DL_ATTEMPTS) and not patch_dld:
+    while (patch_dl_attempts < MAX_PATCH_DL_ATTEMPTS) and not patch_dld:
         try:
             opener = urllib.request.build_opener()
             opener.addheaders = [{'User-Agent', 'Mozilla/5.0'}]
@@ -255,11 +256,15 @@ def makeSkin():
             patch_dld = True
         except:
             patch_dl_attempts += 1
-            print("Error: download attempt" + str(patch_dl_attempts) + " failed.")
+            print("Error: download attempt " + str(patch_dl_attempts) + " failed.")
+            if patch_dl_attempts < MAX_PATCH_DL_ATTEMPTS:
+                time.sleep(5)
 
     if not patch_dld:
         print("Error: patch download attempts failed, exiting...")
         sys.exit(1)
+    else:
+        print("Patch downloaded, proceeding...")
 
     z = zipfile.ZipFile(METRO_PATCH_ZIP, 'r')
     z.extractall(METRO_PATCH_DIR)

--- a/wal_steam.py
+++ b/wal_steam.py
@@ -250,7 +250,6 @@ def makeSkin():
     while (patch_dl_attempts < MAX_PATCH_DL_ATTEMPTS) and not patch_dld:
         try:
             opener = urllib.request.build_opener()
-            opener.addheaders = [{'User-Agent', 'Mozilla/5.0'}]
             urllib.request.install_opener(opener)
             urllib.request.urlretrieve(METRO_PATCH_URL, METRO_PATCH_ZIP)
             patch_dld = True


### PR DESCRIPTION
As mentioned in the issue on the base repository, the useragent specification in the header for the patch download request was causing HTTP 400 responses.  Removing this specification allowed for consistent download successes.  This merge will also add the ability to specify an amount of retries in case of other transient network problems.