### PR TITLE
Undeclared variable bugfix.

### DIFF
--- a/wal_steam.py
+++ b/wal_steam.py
@@ -180,7 +180,7 @@ def getColors(mode):
     print("Reading colors")
     try:
         with open(colorsFile) as f:
-            raw_file = f.readlines()  # save the lines to rawFile
+            rawFile = f.readlines()  # save the lines to rawFile
     except:
         print("Error: Colors file missing. Make sure you've run pywal/wpg before wal_steam")
         sys.exit(1)


### PR DESCRIPTION
# An undeclared variable fix

## Purpose
This is a simple fix related to [Issue 59](https://github.com/kotajacob/wal_steam/issues/59).

## Problem Description

- OS:
```
Description:    Manjaro Linux
Release:        18.0.4
```
- Using `pywal` with `python-wal-steam-git` package from AUR (https://aur.archlinux.org/packages/python-wal-steam-git/)

- Error Message with `wal_steam -w`:
``` 
Wal Steam cache found
Wal Steam config found
Wal Steam skin found
Reading colors
Traceback (most recent call last):
  File "wal_steam.py", line 499, in <module>
    main()
  File "wal_steam.py", line 485, in main
    colors = getColors(mode)
  File "wal_steam.py", line 189, in getColors
    del rawFile[0:11]
NameError: name 'rawFile' is not defined
```