### PR TITLE
Fix --fonts not working properly. 

### DIFF
--- a/wal_steam.py
+++ b/wal_steam.py
@@ -405,7 +405,7 @@ def getArgs():
     arg.add_argument("-u", action="store_true",
         help=f"Force update cache, skin, and config file. {CLI_RED}WARNING:{CLI_END} WILL OVERWRITE config.json")
 
-    arg.add_argument("-f", "--fonts",
+    arg.add_argument("-f", "--fonts", nargs='+',
         help=textwrap.dedent(f'''
             Specify custom fonts. Enter font styles separated by comma.
             {CLI_BOLD}Available styles:{CLI_END} basefont, semibold, semilight, light.
@@ -414,7 +414,7 @@ def getArgs():
 
     arg.add_argument("-a", "--attempts", help="Set the number of patch download attempts (DEFAULT=5)")
 
-    return arg.parse_args()
+    return arg.parse_known_args()
 
 def main():
     # set default mode to wal
@@ -423,7 +423,7 @@ def main():
     mode = 0
 
     # parse the arguments
-    arguments = getArgs()
+    arguments, unknown = getArgs()
     if arguments.version:
         print("Wal Steam", VERSION)
         sys.exit()
@@ -458,8 +458,8 @@ def main():
 
     # allow the user to enter custom font styles
     if arguments.fonts:
-        fonts = parseFontArgs(arguments.fonts)
-        print("Using custom font styles: {}".format(arguments.fonts))
+        fonts = parseFontArgs(' '.join(arguments.fonts))
+        print("Using custom font styles: {}".format(', '.join(fonts)))
     else:
         fonts = ""
 

--- a/wal_steam.py
+++ b/wal_steam.py
@@ -424,6 +424,10 @@ def main():
 
     # parse the arguments
     arguments, unknown = getArgs()
+    
+    if len(unknown) != 0:
+        print("Unknown arguments: {}".format(' '.join(unknown)))
+    
     if arguments.version:
         print("Wal Steam", VERSION)
         sys.exit()


### PR DESCRIPTION
This PR fixes #83 (--fonts "example example example" throwing `unrecognized argument: example example`).
The resulting fonts get added to custom.styles as tested:
![image](https://user-images.githubusercontent.com/20606963/85445895-dc422900-b561-11ea-80bf-a803c6d6cc14.png)

wal_steam itself has another issue, custom.styles doesn't seem to be properly used (it doesn't override fonts), but that's outside the scope of this PR.

The issue could be replicated both on my Arch machine and in a Fedora 32 VM.